### PR TITLE
Removing bad dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,10 +30,8 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.8 // indirect
 	github.com/mitre/heart v0.0.0-20160825192324-0c46b433a490
-	github.com/opencensus-integrations/gomongowrapper v0.0.0-00010101000000-000000000000
 	github.com/pebbe/util v0.0.0-20140716220158-e0e04dfe647c
 	github.com/pkg/errors v0.8.1
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/tidwall/pretty v1.0.0 // indirect
 	github.com/ugorji/go v1.1.5-pre // indirect


### PR DESCRIPTION
This refers to a no longer available version. Since we're not planning on running the mongo backend, I think we can just remove it.